### PR TITLE
Deploy site to GitHub Pages via Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one Pages deployment at a time; let an in-flight run finish rather
+# than cancelling it mid-deploy.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Deploy GitHub Pages
 on:
   push:
     branches: ["master"]
+  pull_request:
+    branches: ["master"]
   workflow_dispatch:
 
 permissions:
@@ -33,6 +35,9 @@ jobs:
         uses: actions/upload-pages-artifact@v3
 
   deploy:
+    # Pull requests only need the build validated above; actually publishing
+    # to the live Pages site happens on master pushes (or a manual dispatch).
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/_config.yml
+++ b/_config.yml
@@ -112,5 +112,6 @@ exclude: [
   "reveal.js/Gruntfile.js",
   "reveal.js/CONTRIBUTING.md",
   "reveal.js/LICENSE",
-  "reveal.js/package.json"
+  "reveal.js/package.json",
+  "cctns-manipur/server"
 ]


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pages.yml`: builds the repo with Jekyll (`actions/jekyll-build-pages`, matching the `github-pages` gem already pinned in `Gemfile`) and deploys it via `actions/deploy-pages` on every push to `master` (or manually via `workflow_dispatch`).
- Excludes `cctns-manipur/server` from the Jekyll build in `_config.yml` — that's backend source (Node/Express + JSON seed data), not a static asset meant to be served over Pages.

This publishes both the existing root slideshow and the CCTNS Manipur prototype from #3. `cctns-manipur/index.html` has no Jekyll front matter, so Jekyll copies it through untouched; it'll be reachable at `<pages-url>/cctns-manipur/`. On GitHub Pages the app has no backend to reach, so it runs entirely on its bundled offline sample data (the fallback already in `assets/js/api.js`) — the same path already verified working with the backend down.

If this repository has never had Pages enabled, `deploy-pages` creates the Pages site automatically on first successful run — no separate Settings change should be needed, unless Pages is disabled for this account/org by policy, in which case the deploy job will report that clearly.

## Test plan
- [x] Validated both YAML files parse correctly
- [ ] Confirm the `Deploy GitHub Pages` workflow run succeeds after merge (Actions tab)
- [ ] Visit `<pages-url>/` to confirm the existing slideshow still renders
- [ ] Visit `<pages-url>/cctns-manipur/` to confirm the CCTNS Manipur dashboard loads and the district/case filters work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HM7vQd9FLKRqunDLA2DZUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HM7vQd9FLKRqunDLA2DZUQ)_